### PR TITLE
fix(build)!: use python 3.10 for new Odoo requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye as base
+FROM python:3.10-slim-bullseye as base
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
@@ -137,12 +137,6 @@ RUN pip3 install --prefix=/usr/local --no-cache-dir --upgrade --requirement http
 
 RUN git clone --depth 100 -b ${ODOO_VERSION} https://github.com/odoo/odoo.git /opt/odoo \
     && pip3 install --editable /opt/odoo \
-    && pip3 -qq install --prefix=/usr/local --no-cache-dir --upgrade \
-    gevent==20.12.1 \
-    greenlet==0.4.17 \
-    Werkzeug==0.15.6 \
-    # debugpy has python2 libraries which can't be compiled with python3
-    debugpy \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 FROM base as production


### PR DESCRIPTION
As of May 9, 2022 Odoo has better dependencies for 15.0, including upgraded gevent, greenlet and Werkzeug for python > 3.9

This removes the need to install better versions on our side, and allows to use an upgraded and oficially supported python 3.10